### PR TITLE
Try a more specific tag to see how dependabot behaves

### DIFF
--- a/opc/Dockerfile
+++ b/opc/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.20@sha256:4b9c0a15e3be72c8455ee5398069c74bcde6d827a139c2c3b5f2db779c5b1db8 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.20.12-3.1713832665@sha256:4b9c0a15e3be72c8455ee5398069c74bcde6d827a139c2c3b5f2db779c5b1db8 AS builder
 
 WORKDIR /app
 COPY . .


### PR DESCRIPTION
In https://github.com/openshift-pipelines/ecosystem-images/pull/25, dependabot did something I didn't expect. It updated both the digest _and_ the tag, moving us to go toolset 1.21. I wanted it to update only the digest but not the tag - so that we just tracked new versions of go-toolset 1.20.

Here, let's see what happens if we pin to a specific fixed tag. Will dependabot semver rules lead to something different? https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file?learn=dependency_version_updates&learnProduct=code-security#docker