### PR TITLE
update hermetic and prefetch-input to avoid calling Cachi2

### DIFF
--- a/.tekton/opc-ecosystem-images-pull-request.yaml
+++ b/.tekton/opc-ecosystem-images-pull-request.yaml
@@ -94,11 +94,11 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "true"
+    - default: "false"
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: '{"packages": [{"path": "opc", "type": "gomod"}, {"type": "rpm"}], "flags": ["gomod-vendor"]}'
+    - default: ''
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/opc-ecosystem-images-push.yaml
+++ b/.tekton/opc-ecosystem-images-push.yaml
@@ -90,11 +90,11 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "true"
+    - default: "false"
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: '{"packages": [{"path": "opc", "type": "gomod"}, {"type": "rpm"}], "flags": ["gomod-vendor"]}'
+    - default: ''
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/opc/Dockerfile
+++ b/opc/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21.9-1.1715774364@sha256:f001ad1001a22fe5f6fc7d876fc172b01c1b7dcd6c498f83a07b425e24275a79 AS builder
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder@sha256:9576ac41e16b2262d2871a4064394d650d73221ceb07d1877772fbe98c6f0b6f AS builder
 
 WORKDIR /app
 COPY . .


### PR DESCRIPTION
changing to avoid go 1.22 dependency issue
Ref : https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1716214741923019?thread_ts=1716207487.975729&cid=C04PZ7H0VA8
